### PR TITLE
Improve clapack-config.cmake to be more standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ include_directories(${CLAPACK_SOURCE_DIR}/INCLUDE)
 add_subdirectory(F2CLIBS)
 add_subdirectory(BLAS)
 add_subdirectory(SRC)
+# There is no install tree, copy the INCLUDE folder into the build tree.
+file(COPY ${CLAPACK_SOURCE_DIR}/INCLUDE DESTINATION ${CLAPACK_BINARY_DIR})
+# Used in clapack-config.cmake.in
+set(CONF_INCLUDE_DIRS ${CLAPACK_BINARY_DIR}/INCLUDE)
+
 if( BUILD_TESTING )
   enable_testing()
   include(CTest)

--- a/clapack-config.cmake.in
+++ b/clapack-config.cmake.in
@@ -1,1 +1,16 @@
-include("@CLAPACK_BINARY_DIR@/clapack-targets.cmake")
+# - Config file for CLAPACK
+# It defines the following variables
+#  CLAPACK_INCLUDE_DIRS - include directories for FooBar
+#  CLAPACK_LIBRARIES    - libraries to link against
+
+# Compute paths
+get_filename_component(CLAPACK_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(CLAPACK_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+
+# Our library dependencies (contains definitions for IMPORTED targets)
+if(NOT TARGET CLAPACK AND NOT CLAPACK_BINARY_DIR)
+  include("@CLAPACK_BINARY_DIR@/clapack-targets.cmake")
+endif()
+
+# These are IMPORTED targets created by clapack-targets.cmake
+set(CLAPACK_LIBRARIES "f2c;blas;lapack")


### PR DESCRIPTION
It defines CLAPACK_INCLUDE_DIRS and CLAPACK_LIBRARIES